### PR TITLE
new String extension added

### DIFF
--- a/SwifterSwift/SwifterSwift/Extensions/StringExtensions.swift
+++ b/SwifterSwift/SwifterSwift/Extensions/StringExtensions.swift
@@ -318,6 +318,15 @@ public extension String {
 	public var toInt8: Int8? {
 		return Int8(self)
 	}
+    
+    /// Return Date value from string of date format
+    public func toDate(withFormat format: String) -> Date {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = format
+        
+        
+        return dateFormatter.date(from: self)!
+    }
 	
 	/// Removes spaces and new lines in beginning and end of string.
 	public mutating func trim() {

--- a/SwifterSwift/SwifterSwift/Extensions/StringExtensions.swift
+++ b/SwifterSwift/SwifterSwift/Extensions/StringExtensions.swift
@@ -319,14 +319,12 @@ public extension String {
 		return Int8(self)
 	}
     
-    /// Return Date value from string of date format
-    public func toDate(withFormat format: String) -> Date {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = format
-        
-        
-        return dateFormatter.date(from: self)!
-    }
+    	/// Return Date value from string of date format
+    	public func toDate(withFormat format: String) -> Date? {
+		let dateFormatter = DateFormatter()
+		dateFormatter.dateFormat = format
+		return dateFormatter.date(from: self)?
+	}
 	
 	/// Removes spaces and new lines in beginning and end of string.
 	public mutating func trim() {


### PR DESCRIPTION
Added new extension for String to convert to Date based on entered format. Refer below for example use

```swift
let dateString = "2016/10/20"
let format = "yyyy/MM/dd"
        
let date = dateString.toDate(withFormat: format)
        
print("The date is ---- \(date)")
```