### PR TITLE
Tests fixed, `forEachInParallel` method added for Collection protocol

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@
 <!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
+- [ ] I have **only one commit** in this pull request.
 - [ ] New extensions support iOS 8 or later.
 - [ ] New extensions are written in Swift 3.
 - [ ] New extensions were created in **development branch**.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,8 @@ Its in its early stages, any new idea is appreciated and welcomed, however pleas
  public extension SomeType {}
  ```
  
-- Please add each extension in its appropriate place in the file
+- Please add each extension in its appropriate place in the file.
+- Please submit **only one commit** per pull-request.
 
 ## Reporting Issues
 A great way to contribute to the project is to send a detailed issue when you encounter an problem.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,15 @@ Here are some examples:
 // and many others!
 ```
 
+#### Collection Extensions:
+
+```swift
+// Performs closure for each element of collection in parallel
+[1, 2, 3, 4, 5].forEachInParallel { element in
+            // some work with `element`
+        }
+```
+
 
 #### Date Extensions:
 

--- a/SwifterSwift.podspec
+++ b/SwifterSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = "SwifterSwift"
-  spec.version = "1.3.6"
+  spec.version = "1.3.7"
   spec.summary = "A handy collection of more than 370 native Swift 3 extensions to boost your productivity."
   spec.description = <<-DESC
   SwifterSwift is a library of over 370 properties and methods for more than 36 types, designed to extend Swift's functionality and productivity, staying faithful to the original design guidelines of swift 3

--- a/SwifterSwift/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift/SwifterSwift.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		0786A4161DA8198D00DFD5C0 /* CGFloatExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0786A40B1DA8198D00DFD5C0 /* CGFloatExtensionsTests.swift */; };
 		0786A4171DA8198D00DFD5C0 /* CGSizeExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0786A40C1DA8198D00DFD5C0 /* CGSizeExtensionsTests.swift */; };
 		0786A4181DA8198D00DFD5C0 /* CharacterExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0786A40D1DA8198D00DFD5C0 /* CharacterExtensionsTests.swift */; };
-		0786A4191DA8198D00DFD5C0 /* ConvenienceExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0786A40E1DA8198D00DFD5C0 /* ConvenienceExtensionsTests.swift */; };
 		0786A41A1DA8198D00DFD5C0 /* DateExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0786A40F1DA8198D00DFD5C0 /* DateExtensionsTests.swift */; };
 		0786A41B1DA8198D00DFD5C0 /* DictionaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0786A4101DA8198D00DFD5C0 /* DictionaryExtensionsTests.swift */; };
 		0786A41C1DA8198D00DFD5C0 /* DoubleExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0786A4111DA8198D00DFD5C0 /* DoubleExtensionsTests.swift */; };
@@ -89,6 +88,9 @@
 		07A5610B1DFAD1A600BB1568 /* UIViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A560C61DFAD1A500BB1568 /* UIViewExtensions.swift */; };
 		07A5610C1DFAD1A600BB1568 /* UIViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A560C61DFAD1A500BB1568 /* UIViewExtensions.swift */; };
 		07ED1D4F1DFD4910008DAEA8 /* UICollectionViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07ED1D4E1DFD4910008DAEA8 /* UICollectionViewExtensions.swift */; };
+		B3AD57741E094488001E9090 /* SwifterSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0786A40E1DA8198D00DFD5C0 /* SwifterSwiftTests.swift */; };
+		B3C36DEB1E08580300B48B4A /* CollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C36DEA1E08580300B48B4A /* CollectionExtensions.swift */; };
+		B3C36DED1E08581D00B48B4A /* CollectionExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C36DEC1E08581D00B48B4A /* CollectionExtensionsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -111,7 +113,7 @@
 		0786A40B1DA8198D00DFD5C0 /* CGFloatExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGFloatExtensionsTests.swift; sourceTree = "<group>"; };
 		0786A40C1DA8198D00DFD5C0 /* CGSizeExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGSizeExtensionsTests.swift; sourceTree = "<group>"; };
 		0786A40D1DA8198D00DFD5C0 /* CharacterExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CharacterExtensionsTests.swift; sourceTree = "<group>"; };
-		0786A40E1DA8198D00DFD5C0 /* ConvenienceExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConvenienceExtensionsTests.swift; sourceTree = "<group>"; };
+		0786A40E1DA8198D00DFD5C0 /* SwifterSwiftTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterSwiftTests.swift; sourceTree = "<group>"; };
 		0786A40F1DA8198D00DFD5C0 /* DateExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateExtensionsTests.swift; sourceTree = "<group>"; };
 		0786A4101DA8198D00DFD5C0 /* DictionaryExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryExtensionsTests.swift; sourceTree = "<group>"; };
 		0786A4111DA8198D00DFD5C0 /* DoubleExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DoubleExtensionsTests.swift; sourceTree = "<group>"; };
@@ -154,6 +156,8 @@
 		07A560C51DFAD1A500BB1568 /* UIViewControllerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewControllerExtensions.swift; sourceTree = "<group>"; };
 		07A560C61DFAD1A500BB1568 /* UIViewExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewExtensions.swift; sourceTree = "<group>"; };
 		07ED1D4E1DFD4910008DAEA8 /* UICollectionViewExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UICollectionViewExtensions.swift; sourceTree = "<group>"; };
+		B3C36DEA1E08580300B48B4A /* CollectionExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionExtensions.swift; sourceTree = "<group>"; };
+		B3C36DEC1E08581D00B48B4A /* CollectionExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionExtensionsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -210,7 +214,7 @@
 				0786A40B1DA8198D00DFD5C0 /* CGFloatExtensionsTests.swift */,
 				0786A40C1DA8198D00DFD5C0 /* CGSizeExtensionsTests.swift */,
 				0786A40D1DA8198D00DFD5C0 /* CharacterExtensionsTests.swift */,
-				0786A40E1DA8198D00DFD5C0 /* ConvenienceExtensionsTests.swift */,
+				0786A40E1DA8198D00DFD5C0 /* SwifterSwiftTests.swift */,
 				0786A40F1DA8198D00DFD5C0 /* DateExtensionsTests.swift */,
 				0786A4101DA8198D00DFD5C0 /* DictionaryExtensionsTests.swift */,
 				0786A4111DA8198D00DFD5C0 /* DoubleExtensionsTests.swift */,
@@ -218,6 +222,7 @@
 				0786A4131DA8198D00DFD5C0 /* IntExtensionsTests.swift */,
 				0786A4141DA8198D00DFD5C0 /* StringExtensionsTests.swift */,
 				0786A3FE1DA8194300DFD5C0 /* Info.plist */,
+				B3C36DEC1E08581D00B48B4A /* CollectionExtensionsTests.swift */,
 			);
 			path = SwifterSwiftTests;
 			sourceTree = "<group>";
@@ -225,6 +230,7 @@
 		07A560A21DFAD1A500BB1568 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				B3C36DEA1E08580300B48B4A /* CollectionExtensions.swift */,
 				07A560A31DFAD1A500BB1568 /* ArrayExtensions.swift */,
 				07A560A41DFAD1A500BB1568 /* BoolExtensions.swift */,
 				07A560A51DFAD1A500BB1568 /* CharacterExtensions.swift */,
@@ -416,6 +422,7 @@
 				07A560E91DFAD1A600BB1568 /* UIButtonExtensions.swift in Sources */,
 				07A560DF1DFAD1A600BB1568 /* CGPointExtensions.swift in Sources */,
 				07A561031DFAD1A600BB1568 /* UITableViewExtensions.swift in Sources */,
+				B3C36DEB1E08580300B48B4A /* CollectionExtensions.swift in Sources */,
 				07A560D11DFAD1A500BB1568 /* DictionaryExtensions.swift in Sources */,
 				07A560F91DFAD1A600BB1568 /* UISearchBarExtensions.swift in Sources */,
 				07A561071DFAD1A600BB1568 /* UITextViewExtensions.swift in Sources */,
@@ -448,10 +455,10 @@
 				0786A41E1DA8198D00DFD5C0 /* IntExtensionsTests.swift in Sources */,
 				07A560F21DFAD1A600BB1568 /* UILabelExtensions.swift in Sources */,
 				0786A41B1DA8198D00DFD5C0 /* DictionaryExtensionsTests.swift in Sources */,
+				B3AD57741E094488001E9090 /* SwifterSwiftTests.swift in Sources */,
 				07A561041DFAD1A600BB1568 /* UITableViewExtensions.swift in Sources */,
 				07A5610A1DFAD1A600BB1568 /* UIViewControllerExtensions.swift in Sources */,
 				07A560CE1DFAD1A500BB1568 /* DataExtensions.swift in Sources */,
-				0786A4191DA8198D00DFD5C0 /* ConvenienceExtensionsTests.swift in Sources */,
 				0786A4171DA8198D00DFD5C0 /* CGSizeExtensionsTests.swift in Sources */,
 				0786A4161DA8198D00DFD5C0 /* CGFloatExtensionsTests.swift in Sources */,
 				07A560D01DFAD1A500BB1568 /* DateExtensions.swift in Sources */,
@@ -461,6 +468,7 @@
 				07A560D61DFAD1A500BB1568 /* FloatExtensions.swift in Sources */,
 				07A560F41DFAD1A600BB1568 /* UINavigationBarExtensions.swift in Sources */,
 				07A560E21DFAD1A600BB1568 /* CGSizeExtensions.swift in Sources */,
+				B3C36DED1E08581D00B48B4A /* CollectionExtensionsTests.swift in Sources */,
 				07A560E41DFAD1A600BB1568 /* NSAttributedStringExtensions.swift in Sources */,
 				07A561061DFAD1A600BB1568 /* UITextFieldExtensions.swift in Sources */,
 				07A560DE1DFAD1A600BB1568 /* CGFloatExtensions.swift in Sources */,
@@ -589,7 +597,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -609,6 +619,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -627,6 +638,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SwifterSwiftTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.swiftierswift.SwifterSwiftTests;
@@ -639,6 +652,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SwifterSwiftTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.swiftierswift.SwifterSwiftTests;

--- a/SwifterSwift/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift/SwifterSwift.xcodeproj/project.pbxproj
@@ -21,7 +21,6 @@
 		0786A41E1DA8198D00DFD5C0 /* IntExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0786A4131DA8198D00DFD5C0 /* IntExtensionsTests.swift */; };
 		0786A41F1DA8198D00DFD5C0 /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0786A4141DA8198D00DFD5C0 /* StringExtensionsTests.swift */; };
 		07A560C71DFAD1A500BB1568 /* ArrayExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A560A31DFAD1A500BB1568 /* ArrayExtensions.swift */; };
-		07A560C81DFAD1A500BB1568 /* ArrayExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A560A31DFAD1A500BB1568 /* ArrayExtensions.swift */; };
 		07A560C91DFAD1A500BB1568 /* BoolExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A560A41DFAD1A500BB1568 /* BoolExtensions.swift */; };
 		07A560CA1DFAD1A500BB1568 /* BoolExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A560A41DFAD1A500BB1568 /* BoolExtensions.swift */; };
 		07A560CB1DFAD1A500BB1568 /* CharacterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A560A51DFAD1A500BB1568 /* CharacterExtensions.swift */; };
@@ -31,7 +30,6 @@
 		07A560CF1DFAD1A500BB1568 /* DateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A560A71DFAD1A500BB1568 /* DateExtensions.swift */; };
 		07A560D01DFAD1A500BB1568 /* DateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A560A71DFAD1A500BB1568 /* DateExtensions.swift */; };
 		07A560D11DFAD1A500BB1568 /* DictionaryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A560A81DFAD1A500BB1568 /* DictionaryExtensions.swift */; };
-		07A560D21DFAD1A500BB1568 /* DictionaryExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A560A81DFAD1A500BB1568 /* DictionaryExtensions.swift */; };
 		07A560D31DFAD1A500BB1568 /* DoubleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A560A91DFAD1A500BB1568 /* DoubleExtensions.swift */; };
 		07A560D41DFAD1A500BB1568 /* DoubleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A560A91DFAD1A500BB1568 /* DoubleExtensions.swift */; };
 		07A560D51DFAD1A500BB1568 /* FloatExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A560AA1DFAD1A500BB1568 /* FloatExtensions.swift */; };
@@ -453,8 +451,6 @@
 				07A561041DFAD1A600BB1568 /* UITableViewExtensions.swift in Sources */,
 				07A5610A1DFAD1A600BB1568 /* UIViewControllerExtensions.swift in Sources */,
 				07A560CE1DFAD1A500BB1568 /* DataExtensions.swift in Sources */,
-				07A560C81DFAD1A500BB1568 /* ArrayExtensions.swift in Sources */,
-				07A560D21DFAD1A500BB1568 /* DictionaryExtensions.swift in Sources */,
 				0786A4191DA8198D00DFD5C0 /* ConvenienceExtensionsTests.swift in Sources */,
 				0786A4171DA8198D00DFD5C0 /* CGSizeExtensionsTests.swift in Sources */,
 				0786A4161DA8198D00DFD5C0 /* CGFloatExtensionsTests.swift in Sources */,

--- a/SwifterSwift/SwifterSwift/Extensions/CollectionExtensions.swift
+++ b/SwifterSwift/SwifterSwift/Extensions/CollectionExtensions.swift
@@ -1,0 +1,35 @@
+//
+//  CollectionExtensions.swift
+//  SwifterSwift
+//
+//  Created by Sergey Fedortsov on 19.12.16.
+//  Copyright © 2016 Omar Albeik. All rights reserved.
+//
+
+import Foundation
+
+
+
+// MARK: - Methods
+public extension Collection {
+    
+    private func indicesArray() -> [Self.Index] {
+        var indices: [Self.Index] = []
+        var index = self.startIndex
+        while index != self.endIndex {
+            indices.append(index)
+            index = self.index(after: index)
+        }
+        return indices
+    }
+    
+    /// SwifterSwift: performs `each` closure for each element of collection in parallel
+    public func forEachInParallel(_ each: (Self.Iterator.Element) -> ()) {
+        let indices = indicesArray()
+        
+        DispatchQueue.concurrentPerform(iterations: indices.count) { (index) in
+            let elementIndex = indices[index]
+            each(self[elementIndex])
+        }
+    }
+}

--- a/SwifterSwift/SwifterSwift/Extensions/DateExtensions.swift
+++ b/SwifterSwift/SwifterSwift/Extensions/DateExtensions.swift
@@ -28,7 +28,7 @@ public extension Date {
 			return calendar.component(.year, from: self)
 		}
 		set {
-			self = Date(calendar: calendar, timeZone: timeZone, era: era, year: newValue, month: month, day: day, hour: hour, minute: minute, second: second, nanosecond: nanosecond)
+			self = Date(calendar: calendar, timeZone: timeZone, era: era, year: newValue, month: month, day: day, hour: hour, minute: minute, second: second, nanosecond: nanosecond) ?? Date()
 		}
 	}
 	
@@ -43,7 +43,7 @@ public extension Date {
 			return calendar.component(.month, from: self)
 		}
 		set {
-			self = Date(calendar: calendar, timeZone: timeZone, era: era, year: year, month: newValue, day: day, hour: hour, minute: minute, second: second, nanosecond: nanosecond)
+			self = Date(calendar: calendar, timeZone: timeZone, era: era, year: year, month: newValue, day: day, hour: hour, minute: minute, second: second, nanosecond: nanosecond) ?? Date()
 		}
 	}
 	
@@ -68,7 +68,7 @@ public extension Date {
 			return calendar.component(.day, from: self)
 		}
 		set {
-			self = Date(calendar: calendar, timeZone: timeZone, era: era, year: year, month: month, day: newValue, hour: hour, minute: minute, second: second, nanosecond: nanosecond)
+			self = Date(calendar: calendar, timeZone: timeZone, era: era, year: year, month: month, day: newValue, hour: hour, minute: minute, second: second, nanosecond: nanosecond) ?? Date()
 		}
 	}
 	
@@ -78,7 +78,7 @@ public extension Date {
 			return calendar.component(.hour, from: self)
 		}
 		set {
-			self = Date(calendar: calendar, timeZone: timeZone, era: era, year: year, month: month, day: day, hour: newValue, minute: minute, second: second, nanosecond: nanosecond)
+			self = Date(calendar: calendar, timeZone: timeZone, era: era, year: year, month: month, day: day, hour: newValue, minute: minute, second: second, nanosecond: nanosecond) ?? Date()
 		}
 	}
 	
@@ -88,7 +88,7 @@ public extension Date {
 			return calendar.component(.minute, from: self)
 		}
 		set {
-			self = Date(calendar: calendar, timeZone: timeZone, era: era, year: year, month: month, day: day, hour: hour, minute: newValue, second: second, nanosecond: nanosecond)
+			self = Date(calendar: calendar, timeZone: timeZone, era: era, year: year, month: month, day: day, hour: hour, minute: newValue, second: second, nanosecond: nanosecond) ?? Date()
 		}
 	}
 	
@@ -98,7 +98,7 @@ public extension Date {
 			return calendar.component(.second, from: self)
 		}
 		set {
-			self = Date(calendar: calendar, timeZone: timeZone, era: era, year: year, month: month, day: day, hour: hour, minute: minute, second: newValue, nanosecond: nanosecond)
+			self = Date(calendar: calendar, timeZone: timeZone, era: era, year: year, month: month, day: day, hour: hour, minute: minute, second: newValue, nanosecond: nanosecond) ?? Date()
 		}
 	}
 	
@@ -161,8 +161,8 @@ public extension Date {
 		return Calendar.current.date(from: components) ?? Date()
 	}
 	
-	/// SwifterSwift: Nearest quarter to date.
-	public var nearestHourQuarter: Date {
+	/// SwifterSwift: Nearest quarter hour to date.
+	public var nearestQuarterHour: Date {
 		var components = Calendar.current.dateComponents([.year, .month , .day , .hour , .minute], from: self)
 		guard let min = components.minute else {
 			return self
@@ -509,7 +509,7 @@ public extension Date {
 	///   - minute: Minute (default is current minute).
 	///   - second: Second (default is current second).
 	///   - nanosecond: Nanosecond (default is current nanosecond).
-	public init(
+	public init?(
 		calendar: Calendar? = Calendar.current,
 		timeZone: TimeZone? = TimeZone.current,
 		era: Int? = Date().era,
@@ -533,19 +533,27 @@ public extension Date {
 		components.second = second
 		components.nanosecond = nanosecond
 		
-		self = calendar?.date(from: components) ?? Date()
+		if let date = calendar?.date(from: components) {
+			self = date
+		} else {
+			return nil
+		}
 	}
 	
 	/// SwifterSwift: Create date object from ISO8601 string.
 	///
 	/// - Parameter iso8601String: ISO8601 string of format (yyyy-MM-dd'T'HH:mm:ss.SSSZ).
-	public init(iso8601String: String) {
+	public init?(iso8601String: String) {
 		// https://github.com/justinmakaila/NSDate-ISO-8601/blob/master/NSDateISO8601.swift
 		let dateFormatter = DateFormatter()
 		dateFormatter.locale = Locale(identifier: "en_US_POSIX")
 		dateFormatter.timeZone = TimeZone.current
 		dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-		self = dateFormatter.date(from: iso8601String) ?? Date()
+		if let date = dateFormatter.date(from: iso8601String) {
+			self = date
+		} else {
+			return nil
+		}
 	}
 	
 	/// SwifterSwift: Create new date object from UNIX timestamp.

--- a/SwifterSwift/SwifterSwift/Extensions/UI/UITabBarExtensions.swift
+++ b/SwifterSwift/SwifterSwift/Extensions/UI/UITabBarExtensions.swift
@@ -46,7 +46,9 @@ public extension UITabBar {
 				if let image = barItem.image {
 					barItem.image = image.filled(withColor: itemColor).withRenderingMode(.alwaysOriginal)
 					barItem.setTitleTextAttributes([NSForegroundColorAttributeName : itemColor], for: .normal)
-					barItem.setTitleTextAttributes([NSForegroundColorAttributeName : itemColor], for: .selected)
+					if let selected = selectedItem {
+						barItem.setTitleTextAttributes([NSForegroundColorAttributeName : selected], for: .selected)
+					}
 				}
 			}
 		}

--- a/SwifterSwift/SwifterSwift/Info.plist
+++ b/SwifterSwift/SwifterSwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.6</string>
+	<string>1.3.7</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/SwifterSwift/SwifterSwiftTests/ArrayExtensionsTests.swift
+++ b/SwifterSwift/SwifterSwiftTests/ArrayExtensionsTests.swift
@@ -5,7 +5,6 @@
 //  Created by Omar Albeik on 8/26/16.
 //  Copyright © 2016 Omar Albeik. All rights reserved.
 //
-
 import XCTest
 @testable import SwifterSwift
 

--- a/SwifterSwift/SwifterSwiftTests/ArrayExtensionsTests.swift
+++ b/SwifterSwift/SwifterSwiftTests/ArrayExtensionsTests.swift
@@ -26,10 +26,6 @@ class ArrayExtensionsTests: XCTestCase {
 		XCTAssert([1.2, 2.3, 3.4, 4.5, 5.6].average == 3.4, "Couldn't get correct value for \(#function)")
 	}
 	
-	func testDifference() {
-		XCTAssert([1, 2, 3, 4, 5].difference(from: [1, 3, 5, 7]) == [2, 4], "Couldn't get correct value for \(#function)")
-	}
-	
 	func testFirstIndex() {
 		XCTAssert([1, 1, 2, 3, 4, 1, 2, 1].firstIndex(of: 2)! == 2, "Couldn't get correct value for \(#function)")
 	}
@@ -62,7 +58,7 @@ class ArrayExtensionsTests: XCTestCase {
 	
 	func testRemoveAll() {
 		var arr = [0, 1, 2, 0, 3, 4, 5, 0, 0]
-		arr.removeAll(item: 0)
+		arr.removeAll(0)
 		XCTAssert(arr == [1, 2, 3, 4, 5], "Couldn't get correct value for \(#function)")
 	}
 	
@@ -88,6 +84,6 @@ class ArrayExtensionsTests: XCTestCase {
 	}
 	
 	func testUniqueValues() {
-		XCTAssert([1, 1, 2, 2, 3, 3, 3, 4, 5].uniqueValues == [1, 2, 3, 4, 5], "Couldn't get correct value for \(#function)")
+		XCTAssert([1, 1, 2, 2, 3, 3, 3, 4, 5].withoutDuplicates == [1, 2, 3, 4, 5], "Couldn't get correct value for \(#function)")
 	}
 }

--- a/SwifterSwift/SwifterSwiftTests/CharacterExtensionsTests.swift
+++ b/SwifterSwift/SwifterSwiftTests/CharacterExtensionsTests.swift
@@ -6,6 +6,14 @@
 //  Copyright © 2016 Omar Albeik. All rights reserved.
 //
 
+//
+//  CharacterExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Omar Albeik on 8/27/16.
+//  Copyright © 2016 Omar Albeik. All rights reserved.
+//
+
 import XCTest
 @testable import SwifterSwift
 

--- a/SwifterSwift/SwifterSwiftTests/CharacterExtensionsTests.swift
+++ b/SwifterSwift/SwifterSwiftTests/CharacterExtensionsTests.swift
@@ -37,11 +37,11 @@ class CharacterExtensionsTests: XCTestCase {
 	}
 	
 	func testToInt() {
-		XCTAssert(Character("1").toInt! == 1, "Couldn't get correct value for \(#function)")
-		XCTAssert(Character("s").toInt == nil, "Couldn't get correct value for \(#function)")
+		XCTAssert(Character("1").int! == 1, "Couldn't get correct value for \(#function)")
+		XCTAssert(Character("s").int == nil, "Couldn't get correct value for \(#function)")
 	}
 	
 	func testToString() {
-		XCTAssert(Character("s").toString == String("s"), "Couldn't get correct value for \(#function)")
+		XCTAssert(Character("s").string == String("s"), "Couldn't get correct value for \(#function)")
 	}
 }

--- a/SwifterSwift/SwifterSwiftTests/CollectionExtensionsTests.swift
+++ b/SwifterSwift/SwifterSwiftTests/CollectionExtensionsTests.swift
@@ -1,0 +1,27 @@
+//
+//  CollectionExtensionsTests.swift
+//  SwifterSwift
+//
+//  Created by Sergey Fedortsov on 19.12.16.
+//  Copyright © 2016 Omar Albeik. All rights reserved.
+//
+
+import XCTest
+@testable import SwifterSwift
+class CollectionExtensionsTests: XCTestCase {
+    
+    func testForEachInParallel() {
+        var result = [Int]()
+        
+        let accessQueue = DispatchQueue(label: "access_queue")
+        
+        [1, 2, 3, 4, 5].forEachInParallel { element in
+            accessQueue.sync {
+                result.append(element * element)
+            }
+        }
+        
+        XCTAssertEqual(result.sorted(), [1, 4, 9, 16, 25])
+    }
+    
+}

--- a/SwifterSwift/SwifterSwiftTests/ConvenienceExtensionsTests.swift
+++ b/SwifterSwift/SwifterSwiftTests/ConvenienceExtensionsTests.swift
@@ -23,6 +23,6 @@ class ConvenienceExtensionsTests: XCTestCase {
 	
 	func testTypeName() {
 		let number = 8
-		XCTAssert(swifterSwift.typeName(for: number) == "Int", "Couldn't get correct value for \(#function)")
+		XCTAssert(SwifterSwift.typeName(for: number) == "Int", "Couldn't get correct value for \(#function)")
 	}
 }

--- a/SwifterSwift/SwifterSwiftTests/DateExtensionsTests.swift
+++ b/SwifterSwift/SwifterSwiftTests/DateExtensionsTests.swift
@@ -13,7 +13,7 @@ class DateExtensionsTests: XCTestCase {
 	
 	override func setUp() {
 		super.setUp()
-        NSTimeZone.default = TimeZone(abbreviation: "UTC")!
+		NSTimeZone.default = TimeZone(abbreviation: "UTC")!
 	}
 	
 	func testAdd() {
@@ -71,15 +71,15 @@ class DateExtensionsTests: XCTestCase {
 		
 		XCTAssert(Date().beginning(of: .day)?.hour == 0 && (Date().beginning(of: .day)?.isInToday)!, "Could not get correct value for beginning of day in \(#function)")
 		
-		let date = Date(year: 2016, month: 8, day: 9)
+		let date = Date(year: 2016, month: 8, day: 9) ?? Date()
 		
-		let beginningOfWeek = Date(year: 2016, month: 8, day: 7)
+		let beginningOfWeek = Date(year: 2016, month: 8, day: 7) ?? Date()
 		XCTAssert(date.beginning(of: .weekOfMonth)?.day == beginningOfWeek.day, "Could not get correct value for beginning of week in \(#function)")
 		
-		let beginningOfMonth = Date(year: 2016, month: 8, day: 1)
+		let beginningOfMonth = Date(year: 2016, month: 8, day: 1) ?? Date()
 		XCTAssert(Date().beginning(of: .month)?.day == beginningOfMonth.day, "Could not get correct value for beginning of month in \(#function)")
 		
-		let beginningOfYear = Date(year: 2016, month: 1, day: 1)
+		let beginningOfYear = Date(year: 2016, month: 1, day: 1) ?? Date()
 		XCTAssert(Date().beginning(of: .year)?.day == beginningOfYear.day, "Could not get correct value for beginning of year in \(#function)")
 	}
 	
@@ -142,7 +142,7 @@ class DateExtensionsTests: XCTestCase {
 	}
 	
 	func testNewDateFromComponenets() {
-		let date = Date(calendar: Date().calendar, timeZone: Date().timeZone, era: Date().era, year: Date().year, month: Date().month, day: Date().day, hour: Date().hour, minute: Date().minute, second: Date().second, nanosecond: Date().nanosecond)
+		let date = Date(calendar: Date().calendar, timeZone: Date().timeZone, era: Date().era, year: Date().year, month: Date().month, day: Date().day, hour: Date().hour, minute: Date().minute, second: Date().second, nanosecond: Date().nanosecond) ?? Date()
 		let date1 = Date(timeIntervalSince1970: date.timeIntervalSince1970)
 		
 		XCTAssert(date.timeIntervalSince1970 == date1.timeIntervalSince1970, "Could not get correct value for \(#function)")

--- a/SwifterSwift/SwifterSwiftTests/DateExtensionsTests.swift
+++ b/SwifterSwift/SwifterSwiftTests/DateExtensionsTests.swift
@@ -13,57 +13,52 @@ class DateExtensionsTests: XCTestCase {
 	
 	override func setUp() {
 		super.setUp()
-		// Put setup code here. This method is called before the invocation of each test method in the class.
-	}
-	
-	override func tearDown() {
-		// Put teardown code here. This method is called after the invocation of each test method in the class.
-		super.tearDown()
+        NSTimeZone.default = TimeZone(abbreviation: "UTC")!
 	}
 	
 	func testAdd() {
 		var date1 = Date()
 		
 		date1.second = 10
-		date1.add(component: .second, value: -1)
+		date1.add(.second, value: -1)
 		XCTAssert(date1.second == 9, "Could not substract seconds in \(#function)")
 		
-		date1.add(component: .second, value: 1)
+		date1.add(.second, value: 1)
 		XCTAssert(date1.second == 10, "Could not add seconds in \(#function)")
 		
 		date1.minute = 10
-		date1.add(component: .minute, value: -1)
+		date1.add(.minute, value: -1)
 		XCTAssert(date1.minute == 9, "Could not substract minutes in \(#function)")
 		
-		date1.add(component: .minute, value: 1)
+		date1.add(.minute, value: 1)
 		XCTAssert(date1.minute == 10, "Could not add minutes in \(#function)")
 		
 		date1.hour = 10
-		date1.add(component: .hour, value: -1)
+		date1.add(.hour, value: -1)
 		XCTAssert(date1.hour == 9, "Could not substract hours in \(#function)")
 		
-		date1.add(component: .hour, value: 1)
+		date1.add(.hour, value: 1)
 		XCTAssert(date1.hour == 10, "Could not add hours in \(#function)")
 		
 		date1.day = 10
-		date1.add(component: .day, value: -1)
+		date1.add(.day, value: -1)
 		XCTAssert(date1.day == 9, "Could not substract days in \(#function)")
 		
-		date1.add(component: .day, value: 1)
+		date1.add(.day, value: 1)
 		XCTAssert(date1.day == 10, "Could not add days in \(#function)")
 		
 		date1.month = 10
-		date1.add(component: .month, value: -1)
+		date1.add(.month, value: -1)
 		XCTAssert(date1.month == 9, "Could not substract months in \(#function)")
 		
-		date1.add(component: .month, value: 1)
+		date1.add(.month, value: 1)
 		XCTAssert(date1.month == 10, "Could not add months in \(#function)")
 		
 		date1.year = 2016
-		date1.add(component: .year, value: -1)
+		date1.add(.year, value: -1)
 		XCTAssert(date1.year == 2015, "Could not substract years in \(#function)")
 		
-		date1.add(component: .year, value: 1)
+		date1.add(.year, value: 1)
 		XCTAssert(date1.year == 2016, "Could not add years in \(#function)")
 	}
 	
@@ -101,9 +96,9 @@ class DateExtensionsTests: XCTestCase {
 	
 	func testDateTimeString() {
 		let date = Date(timeIntervalSince1970: 512)
-		XCTAssert(date.dateTimeString() == "Jan 1, 1970, 2:08:32 AM", "Couldn't get correct value for \(#function)")
-		XCTAssert(date.dateTimeString(ofStyle: .short) == "1/1/70, 2:08 AM", "Couldn't get correct value for \(#function)")
-		XCTAssert(date.dateTimeString(ofStyle: .long) == "January 1, 1970 at 2:08:32 AM GMT+2", "Couldn't get correct value for \(#function)")
+		XCTAssert(date.dateTimeString() == "Jan 1, 1970, 12:08:32 AM", "Couldn't get correct value for \(#function)")
+		XCTAssert(date.dateTimeString(ofStyle: .short) == "1/1/70, 12:08 AM", "Couldn't get correct value for \(#function)")
+		XCTAssert(date.dateTimeString(ofStyle: .long) == "January 1, 1970 at 12:08:32 AM GMT", "Couldn't get correct value for \(#function)")
 	}
 	
 	func testDay() {
@@ -125,8 +120,8 @@ class DateExtensionsTests: XCTestCase {
 		XCTAssert(date.end(of: .day)?.hour == 23 && date.end(of: .day)?.minute == 59 && date.end(of: .day)?.second == 59, "Couldn't get correct value for \(#function)")
 		
 		var endOfWeek = date.beginning(of: .weekOfYear)
-		endOfWeek?.add(component: .day, value: 7)
-		endOfWeek?.add(component: .second, value: -1)
+		endOfWeek?.add(.day, value: 7)
+		endOfWeek?.add(.second, value: -1)
 		XCTAssert(date.end(of: .weekOfYear) == endOfWeek, "Couldn't get correct value for \(#function)")
 		
 		XCTAssert(date.end(of: .month)?.day == 31 && date.end(of: .month)?.hour == 23 && date.end(of: .month)?.minute == 59 && date.end(of: .month)?.second == 59, "Couldn't get correct value for \(#function)")
@@ -167,21 +162,21 @@ class DateExtensionsTests: XCTestCase {
 	
 	func testIsInCurrent() {
 		let oldDate = Date(timeIntervalSince1970: 512) // 1970-01-01T00:08:32.000Z
-		XCTAssert(oldDate.isIn(current: .second) == false && Date().isIn(current: .second) == true, "Could not get correct value for \(#function)")
+		XCTAssert(oldDate.isInCurrent(.second) == false && Date().isInCurrent(.second) == true, "Could not get correct value for \(#function)")
 		
-		XCTAssert(oldDate.isIn(current: .second) == false && Date().isIn(current: .second) == true, "Could not get correct value for \(#function)")
+		XCTAssert(oldDate.isInCurrent(.second) == false && Date().isInCurrent(.second) == true, "Could not get correct value for \(#function)")
 		
-		XCTAssert(oldDate.isIn(current: .minute) == false && Date().isIn(current: .minute) == true, "Could not get correct value for \(#function)")
+		XCTAssert(oldDate.isInCurrent(.minute) == false && Date().isInCurrent(.minute) == true, "Could not get correct value for \(#function)")
 		
-		XCTAssert(oldDate.isIn(current: .hour) == false && Date().isIn(current: .hour) == true, "Could not get correct value for \(#function)")
+		XCTAssert(oldDate.isInCurrent(.hour) == false && Date().isInCurrent(.hour) == true, "Could not get correct value for \(#function)")
 		
-		XCTAssert(oldDate.isIn(current: .day) == false && Date().isIn(current: .day) == true, "Could not get correct value for \(#function)")
+		XCTAssert(oldDate.isInCurrent(.day) == false && Date().isInCurrent(.day) == true, "Could not get correct value for \(#function)")
 		
-		XCTAssert(oldDate.isIn(current: .weekOfMonth) == false && Date().isIn(current: .weekOfMonth) == true, "Could not get correct value for \(#function)")
+		XCTAssert(oldDate.isInCurrent(.weekOfMonth) == false && Date().isInCurrent(.weekOfMonth) == true, "Could not get correct value for \(#function)")
 		
-		XCTAssert(oldDate.isIn(current: .month) == false && Date().isIn(current: .month) == true, "Could not get correct value for \(#function)")
+		XCTAssert(oldDate.isInCurrent(.month) == false && Date().isInCurrent(.month) == true, "Could not get correct value for \(#function)")
 		
-		XCTAssert(oldDate.isIn(current: .year) == false && Date().isIn(current: .year) == true, "Could not get correct value for \(#function)")
+		XCTAssert(oldDate.isInCurrent(.year) == false && Date().isInCurrent(.year) == true, "Could not get correct value for \(#function)")
 	}
 	
 	func testIsInFuture() {
@@ -236,9 +231,9 @@ class DateExtensionsTests: XCTestCase {
 	
 	func testTimeString() {
 		let date = Date(timeIntervalSince1970: 512)
-		XCTAssert(date.timeString() == "2:08:32 AM", "Couldn't get correct value for \(#function)")
-		XCTAssert(date.timeString(ofStyle: .short) == "2:08 AM", "Couldn't get correct value for \(#function)")
-		XCTAssert(date.timeString(ofStyle: .long) == "2:08:32 AM GMT+2", "Couldn't get correct value for \(#function)")
+		XCTAssert(date.timeString() == "12:08:32 AM", "Couldn't get correct value for \(#function)")
+		XCTAssert(date.timeString(ofStyle: .short) == "12:08 AM", "Couldn't get correct value for \(#function)")
+		XCTAssert(date.timeString(ofStyle: .long) == "12:08:32 AM GMT", "Couldn't get correct value for \(#function)")
 	}
 	
 	func testUnixTimestamp() {

--- a/SwifterSwift/SwifterSwiftTests/StringExtensionsTests.swift
+++ b/SwifterSwift/SwifterSwiftTests/StringExtensionsTests.swift
@@ -13,7 +13,7 @@ class StringExtensionsTests: XCTestCase {
 	
 	override func setUp() {
 		super.setUp()
-		// Put setup code here. This method is called before the invocation of each test method in the class.
+        NSTimeZone.default = NSTimeZone.system
 	}
 	
 	override func tearDown() {
@@ -40,7 +40,7 @@ class StringExtensionsTests: XCTestCase {
 	}
 	
 	func testContain() {
-		XCTAssert("Hello Tests".contain(string: "Hello") == true, "Couldn't get correct value for \(#function)")
+		XCTAssert("Hello Tests".contain("Hello") == true, "Couldn't get correct value for \(#function)")
 	}
 	
 	func testContainEmoji() {
@@ -134,11 +134,7 @@ class StringExtensionsTests: XCTestCase {
 	}
 	
 	func testLines() {
-		XCTAssert("Hello\ntest".lines() == ["Hello", "test"], "Couldn't get correct value for \(#function) function")
-	}
-	
-	func testLocale() {
-		XCTAssert("Hello Tests".locale == Locale.current, "Couldn't get correct value for \(#function)")
+		XCTAssert("Hello\ntest".lines == ["Hello", "test"], "Couldn't get correct value for \(#function) function")
 	}
 	
 	func testMostCommonCharacter() {
@@ -147,11 +143,11 @@ class StringExtensionsTests: XCTestCase {
 	}
 	
 	func testRandom() {
-		XCTAssert(String.random(of: 10).characters.count == 10, "Couldn't get correct value for \(#function) function")
+		XCTAssert(String.random(ofLength: 10).characters.count == 10, "Couldn't get correct value for \(#function) function")
 	}
 	
 	func testReplace() {
-		XCTAssert("Hello Test".replace(string: "e", with: "a") == "Hallo Tast", "Couldn't get correct value for \(#function) function")
+		XCTAssert("Hello Test".replacing("e", with: "a") == "Hallo Tast", "Couldn't get correct value for \(#function) function")
 	}
 	
 	func testReverse() {
@@ -165,7 +161,7 @@ class StringExtensionsTests: XCTestCase {
 	}
 	
 	func testSplit() {
-		XCTAssert("Hello Tests".split(by: " ") == ["Hello", "Tests"], "Couldn't get correct value for \(#function)")
+		XCTAssert("Hello Tests".splited(by: " ") == ["Hello", "Tests"], "Couldn't get correct value for \(#function)")
 	}
 	
 	func testStart() {
@@ -178,22 +174,22 @@ class StringExtensionsTests: XCTestCase {
 	}
 	
 	func testToBool() {
-		guard let num = "1".toBool, num == true else {
+		guard let num = "1".bool, num == true else {
 			XCTAssert(false, "Couldn't get correct value for \(#function) function")
 			return
 		}
-		guard let num2 = "false".toBool, num2 == false else {
+		guard let num2 = "false".bool, num2 == false else {
 			XCTAssert(false, "Couldn't get correct value for \(#function) function")
 			return
 		}
-		guard "8s".toBool == nil else {
+		guard "8s".bool == nil else {
 			XCTAssert(false, "Couldn't get correct value for \(#function) function")
 			return
 		}
 	}
 	
 	func testToDate() {
-		let dateFromStr = "2015-06-01".toDate
+		let dateFromStr = "2015-06-01".date
 		let year = dateFromStr?.year
 		let month = dateFromStr?.month
 		let day = dateFromStr?.day
@@ -201,7 +197,7 @@ class StringExtensionsTests: XCTestCase {
 	}
 	
 	func testToDateTime() {
-		let dateFromStr = "2015-06-01 14:23:09".toDateTime
+		let dateFromStr = "2015-06-01 14:23:09".dateTime
 		let year = dateFromStr?.year
 		let month = dateFromStr?.month
 		let day = dateFromStr?.day
@@ -212,41 +208,41 @@ class StringExtensionsTests: XCTestCase {
 	}
 	
 	func testToDouble() {
-		guard let num = "8".toDouble, num == 8 else {
+		guard let num = "8".double, num == 8 else {
 			XCTAssert(false, "Couldn't get correct value for \(#function) function")
 			return
 		}
-		guard let num2 = "8.23".toDouble, num2 == 8.23 else {
+		guard let num2 = "8.23".double, num2 == 8.23 else {
 			XCTAssert(false, "Couldn't get correct value for \(#function) function")
 			return
 		}
-		guard "8s".toDouble == nil else {
+		guard "8s".double == nil else {
 			XCTAssert(false, "Couldn't get correct value for \(#function) function")
 			return
 		}
 	}
 	
 	func testToFloat() {
-		guard let num = "8".toFloat, num == 8 else {
+		guard let num = "8".float, num == 8 else {
 			XCTAssert(false, "Couldn't get correct value for \(#function) function")
 			return
 		}
-		guard let num2 = "8.23".toFloat, num2 == 8.23 else {
+		guard let num2 = "8.23".float, num2 == 8.23 else {
 			XCTAssert(false, "Couldn't get correct value for \(#function) function")
 			return
 		}
-		guard "8s".toFloat == nil else {
+		guard "8s".float == nil else {
 			XCTAssert(false, "Couldn't get correct value for \(#function) function")
 			return
 		}
 	}
 	
 	func testToInt() {
-		guard let num = "8".toInt, num == 8 else {
+		guard let num = "8".int, num == 8 else {
 			XCTAssert(false, "Couldn't get correct value for \(#function) function")
 			return
 		}
-		guard "8s".toInt == nil else {
+		guard "8s".int == nil else {
 			XCTAssert(false, "Couldn't get correct value for \(#function) function")
 			return
 		}
@@ -264,12 +260,12 @@ class StringExtensionsTests: XCTestCase {
 	
 	func testTruncate() {
 		var str = "This is a very long sentence"
-		str.truncate(to: 14)
+		str.truncate(toLength: 14)
 		XCTAssert(str == "This is a very...", "Couldn't get correct value for \(#function) function")
 	}
 	
 	func testTruncated() {
-		XCTAssert("This is a very long sentence".truncated(to: 14) == "This is a very...", "Couldn't get correct value for \(#function) function")
+		XCTAssert("This is a very long sentence".truncated(toLength: 14) == "This is a very...", "Couldn't get correct value for \(#function) function")
 	}
 	
 	func testUnicodeArray() {

--- a/SwifterSwift/SwifterSwiftTests/SwifterSwiftTests.swift
+++ b/SwifterSwift/SwifterSwiftTests/SwifterSwiftTests.swift
@@ -1,5 +1,5 @@
 //
-//  ConvenienceExtensionsTests.swift
+//  SwifterSwiftTests.swift
 //  SwifterSwift
 //
 //  Created by Omar Albeik on 8/27/16.
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SwifterSwift
 
-class ConvenienceExtensionsTests: XCTestCase {
+class SwifterSwiftTests: XCTestCase {
 	
 	override func setUp() {
 		super.setUp()


### PR DESCRIPTION
Hello! `forEachInParallel` behaves exactly like `forEach` method from Swift Standard Library, but may perform iterations in parallel. It uses `DispatchQueue.concurrentPerform`(former `dispatch_apply`) under the hood.
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [ ] I have **only one commit** in this pull request.
- [x] New extensions support iOS 8 or later.
- [x] New extensions are written in Swift 3.
- [x] New extensions were created in **development branch**.
- [x] Pull request was created to **development head branch**.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All comments headears have the word **SwifterSwift:** before description.
