### PR TITLE
Colon missing in date extension in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ Date().isInToday -> true
 Date().add(.month, value: 1)
 
 // Return date at the beginning of current day
-Date().beginning(of .day)
+Date().beginning(of: .day)
 
 // Return date at the end of current month
-Date().end(of .month)
+Date().end(of: .month)
 
 // Check if date is in current calendar unit
 Date().isInCurrent(.month) -> true


### PR DESCRIPTION
Colon missing for date methods beginning and end.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have **only one commit** in this pull request.
- [x] New extensions support iOS 8 or later.
- [x] New extensions are written in Swift 3.
- [x] New extensions were created in **development branch**.
- [x] Pull request was created to **development head branch**.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All comments headears have the word **SwifterSwift:** before description.
