### PR TITLE
safe way to access array index elements no worry of out of bounds

### DIFF
--- a/Source/Extensions/ArrayExtensions.swift
+++ b/Source/Extensions/ArrayExtensions.swift
@@ -211,16 +211,3 @@ public extension Array where Element: Equatable {
 	}
 	
 }
-
-
-extension Collection where Indices.Iterator.Element == Index {
-    
-    /// SwifterSwift: safe protects the array from out of bounds by use of optional
-    ///
-    ///- Parameter index: index of element to access element.
-    ///- Returns: an element if found at index else returns nil
-    ///- Usage: array[safe: index]
-    subscript (safe index: Index) -> Generator.Element? {
-        return indices.contains(index) ? self[index] : nil
-    }
-}

--- a/Source/Extensions/ArrayExtensions.swift
+++ b/Source/Extensions/ArrayExtensions.swift
@@ -211,3 +211,16 @@ public extension Array where Element: Equatable {
 	}
 	
 }
+
+
+extension Collection where Indices.Iterator.Element == Index {
+    
+    /// SwifterSwift: safe protects the array from out of bounds by use of optional
+    ///
+    ///- Parameter index: index of element to access element.
+    ///- Returns: an element if found at index else returns nil
+    ///- Usage: array[safe: index]
+    subscript (safe index: Index) -> Generator.Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Source/Extensions/CollectionExtensions.swift
+++ b/Source/Extensions/CollectionExtensions.swift
@@ -37,10 +37,10 @@ public extension Collection {
 
 extension Collection where Indices.Iterator.Element == Index {
     
-    /// SwifterSwift: safe protects the array from out of bounds by use of optional
+    /// SwifterSwift: Safe protects the array from out of bounds by use of optional.
     ///
-    ///- Parameter index: index of element to access element.
-    ///- Returns: an element if found at index else returns nil
+    ///- Parameter index: Index of element to access element.
+    ///- Returns: Optional element at index (if applicable).
     ///- Usage: array[safe: index]
     subscript (safe index: Index) -> Generator.Element? {
         return indices.contains(index) ? self[index] : nil

--- a/Source/Extensions/CollectionExtensions.swift
+++ b/Source/Extensions/CollectionExtensions.swift
@@ -34,3 +34,15 @@ public extension Collection {
 		}
 	}
 }
+
+extension Collection where Indices.Iterator.Element == Index {
+    
+    /// SwifterSwift: safe protects the array from out of bounds by use of optional
+    ///
+    ///- Parameter index: index of element to access element.
+    ///- Returns: an element if found at index else returns nil
+    ///- Usage: array[safe: index]
+    subscript (safe index: Index) -> Generator.Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have **only one commit** in this pull request.
- [x] New extensions support iOS 8 or later.
- [x] New extensions are written in Swift 3.
- [x] New extensions were created in **development branch**.
- [x] Pull request was created to **development head branch**.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All comments headers have the word **SwifterSwift:** before description.
