### PR TITLE
fix info life location for tests target

### DIFF
--- a/SwifterSwift.xcodeproj/project.pbxproj
+++ b/SwifterSwift.xcodeproj/project.pbxproj
@@ -569,7 +569,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = "";
-				INFOPLIST_FILE = SwifterSwiftTests/Info.plist;
+				INFOPLIST_FILE = Tests/SwifterSwiftTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.omaralbeik.SwifterSwiftTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -583,7 +583,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = "";
-				INFOPLIST_FILE = SwifterSwiftTests/Info.plist;
+				INFOPLIST_FILE = Tests/SwifterSwiftTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.omaralbeik.SwifterSwiftTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Hello. Looks like the location of info.plist for tests target was incorrect and I couldn't run the test suite locally. This change fixes it.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have **only one commit** in this pull request.
- [ ] New extensions support iOS 8 or later.
- [ ] New extensions are written in Swift 3.
- [ ] New extensions were created in **development branch**.
- [x] Pull request was created to **development head branch**.
- [ ] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [ ] All comments headears have the word **SwifterSwift:** before description.
