### PR TITLE
Add String slice method and tests

### DIFF
--- a/Source/Extensions/StringExtensions.swift
+++ b/Source/Extensions/StringExtensions.swift
@@ -410,9 +410,11 @@ public extension String {
 	///   - length: Amount of characters to be sliced after given index.
 	/// - Returns: Sliced substring of length number of characters (if applicable) (example: "Hello world".slicing(from: 6, length: 5) -> "world")
 	public func slicing(from i: Int, length: Int) -> String? {
-		guard length >= 0, i >= 0, i < characters.count,
-			i.advanced(by: length) <= characters.count  else {
-				return nil
+		guard length >= 0, i >= 0, i < characters.count  else {
+			return nil
+		}
+		guard i.advanced(by: length) <= characters.count else {
+			return slice(at: i)
 		}
 		guard length > 0 else {
 			return ""

--- a/Source/Extensions/StringExtensions.swift
+++ b/Source/Extensions/StringExtensions.swift
@@ -414,7 +414,7 @@ public extension String {
 			return nil
 		}
 		guard i.advanced(by: length) <= characters.count else {
-			return slice(at: i)
+			return slicing(at: i)
 		}
 		guard length > 0 else {
 			return ""

--- a/Source/Extensions/StringExtensions.swift
+++ b/Source/Extensions/StringExtensions.swift
@@ -402,6 +402,61 @@ public extension String {
 	public mutating func reverse() {
 		self = String(characters.reversed())
 	}
+
+	/// SwifterSwift: Slice string.
+	/// - Parameters:
+	///   - at: string index the slicing should start from.
+	///   - length: amount of characters to be sliced.
+	/// - Returns: sliced substring of length number of characters or nil
+
+	public func slice(at: Int, length: Int) -> String? {
+		if length < 0 {
+			return nil
+		}
+
+		if length == 0 {
+			if at > characters.count {
+				return nil
+			} else {
+				return ""
+			}
+		}
+
+		if at < 0  {
+			let fromIndex = index(endIndex, offsetBy: at)
+			let toIndex = index(fromIndex, offsetBy: (length-1))
+
+			return self[fromIndex...toIndex]
+		} else {
+			let fromIndex = index(startIndex, offsetBy: at)
+			let toIndex = index(startIndex, offsetBy: (length+at-1))
+
+			return self[fromIndex...toIndex]
+		}
+	}
+
+	/// SwifterSwift: Slice string.
+	/// - Parameters:
+	///   - at: index of the character that should be sliced
+	/// - Returns: returns a substring of a character at a given index or nil
+
+	public func slice(at: Int) -> String? {
+		if at >= characters.count {
+			return nil
+		}
+
+		if at < -characters.count {
+			return nil
+		}
+
+		if at >= 0 {
+			let fromIndex = index(startIndex, offsetBy: at)
+			return self[fromIndex...fromIndex]
+		} else {
+			let fromIndex = index(endIndex, offsetBy: at)
+			return self[fromIndex...fromIndex]
+		}
+	}
 	
 	/// SwifterSwift: Array of strings separated by given string.
 	///

--- a/Source/Extensions/StringExtensions.swift
+++ b/Source/Extensions/StringExtensions.swift
@@ -440,6 +440,9 @@ public extension String {
 	///   - end: String index the slicing should end at.
 	/// - Returns: Sliced substring starting from start index, and ends at end index (if applicable) (example: "Hello world".slicing(from: 6, to: 11) -> "world")
 	public func slicing(from start: Int, to end: Int) -> String? {
+		guard end >= start else {
+			return nil
+		}
 		return self[start..<end]
 	}
 	

--- a/Source/Extensions/StringExtensions.swift
+++ b/Source/Extensions/StringExtensions.swift
@@ -403,7 +403,7 @@ public extension String {
 		self = String(characters.reversed())
 	}
 
-		/// SwifterSwift: Sliced string from a start index with length.
+	/// SwifterSwift: Sliced string from a start index with length.
 	///
 	/// - Parameters:
 	///   - i: String index the slicing should start from.

--- a/Source/Extensions/StringExtensions.swift
+++ b/Source/Extensions/StringExtensions.swift
@@ -403,58 +403,72 @@ public extension String {
 		self = String(characters.reversed())
 	}
 
-	/// SwifterSwift: Slice string.
+		/// SwifterSwift: Sliced string from a start index with length.
+	///
 	/// - Parameters:
-	///   - at: string index the slicing should start from.
-	///   - length: amount of characters to be sliced.
-	/// - Returns: sliced substring of length number of characters or nil
-
-	public func slice(at: Int, length: Int) -> String? {
-		if length < 0 {
-			return nil
-		}
-
-		if length == 0 {
-			if at > characters.count {
+	///   - i: String index the slicing should start from.
+	///   - length: Amount of characters to be sliced after given index.
+	/// - Returns: Sliced substring of length number of characters (if applicable) (example: "Hello world".slicing(from: 6, length: 5) -> "world")
+	public func slicing(from i: Int, length: Int) -> String? {
+		guard length >= 0, i >= 0, i < characters.count,
+			i.advanced(by: length) <= characters.count  else {
 				return nil
-			} else {
-				return ""
-			}
 		}
-
-		if at < 0  {
-			let fromIndex = index(endIndex, offsetBy: at)
-			let toIndex = index(fromIndex, offsetBy: (length-1))
-
-			return self[fromIndex...toIndex]
-		} else {
-			let fromIndex = index(startIndex, offsetBy: at)
-			let toIndex = index(startIndex, offsetBy: (length+at-1))
-
-			return self[fromIndex...toIndex]
+		guard length > 0 else {
+			return ""
+		}
+		return self[i..<i.advanced(by: length)]
+	}
+	
+	/// SwifterSwift: Slice given string from a start index with length (if applicable).
+	///
+	/// - Parameters:
+	///   - i: String index the slicing should start from.
+	///   - length: Amount of characters to be sliced after given index.
+	public mutating func slice(from i: Int, length: Int) {
+		if let str = slicing(from: i, length: length) {
+			self = str
 		}
 	}
-
-	/// SwifterSwift: Slice string.
+	
+	/// SwifterSwift: Sliced string from a start index to an end index.
+	///
 	/// - Parameters:
-	///   - at: index of the character that should be sliced
-	/// - Returns: returns a substring of a character at a given index or nil
-
-	public func slice(at: Int) -> String? {
-		if at >= characters.count {
+	///   - start: String index the slicing should start from.
+	///   - end: String index the slicing should end at.
+	/// - Returns: Sliced substring starting from start index, and ends at end index (if applicable) (example: "Hello world".slicing(from: 6, to: 11) -> "world")
+	public func slicing(from start: Int, to end: Int) -> String? {
+		return self[start..<end]
+	}
+	
+	/// SwifterSwift: Slice given string from a start index to an end index (if applicable).
+	///
+	/// - Parameters:
+	///   - start: String index the slicing should start from.
+	///   - end: String index the slicing should end at.
+	public mutating func slice(from start: Int, to end: Int) {
+		if let str = slicing(from: start, to: end) {
+			self = str
+		}
+	}
+	
+	/// SwifterSwift: Sliced string from a start index.
+	///
+	/// - Parameter i: String index the slicing should start from.
+	/// - Returns: Sliced substring starting from start index (if applicable) (example: "Hello world".slicing(at: 6) -> "world")
+	public func slicing(at i: Int) -> String? {
+		guard i < characters.count else {
 			return nil
 		}
-
-		if at < -characters.count {
-			return nil
-		}
-
-		if at >= 0 {
-			let fromIndex = index(startIndex, offsetBy: at)
-			return self[fromIndex...fromIndex]
-		} else {
-			let fromIndex = index(endIndex, offsetBy: at)
-			return self[fromIndex...fromIndex]
+		return self[i..<characters.count]
+	}
+	
+	/// SwifterSwift: Slice given string from a start index (if applicable).
+	///
+	/// - Parameter i: String index the slicing should start from.
+	public mutating func slice(at i: Int) {
+		if let str = slicing(at: i) {
+			self = str
 		}
 	}
 	

--- a/Tests/SwifterSwiftTests/StringExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/StringExtensionsTests.swift
@@ -161,15 +161,16 @@ class StringExtensionsTests: XCTestCase {
 	}
 
 	func testSlice() {
-		let errMessage = "Couldn't get correct value for \(#function) function"
+		let error = "Couldn't get correct value for \(#function) function"
 		
-		XCTAssertEqual("12345678".slice(at: 2, length: 3)!, "345", errMessage)
-		XCTAssertEqual("12345678".slice(at: 2, length: 0)!, "", errMessage)
-		XCTAssertEqual("12345678".slice(at: 12, length: 0), nil, errMessage)
-		XCTAssertEqual("12345678".slice(at: -2, length: 2)!, "78", errMessage)
-		XCTAssertEqual("12345678".slice(at: 2)!, "3", errMessage)
-		XCTAssertEqual("12345678".slice(at: -1)!, "8", errMessage)
-		XCTAssertEqual("12345678".slice(at: -10), nil, errMessage)
+		XCTAssertEqual("12345678".slicing(from: 2, length: 3)!, "345", error)
+		XCTAssertEqual("12345678".slicing(from: 2, length: 3)!, "345", error)
+		XCTAssertEqual("12345678".slicing(from: 2, length: 0)!, "", error)
+		XCTAssertEqual("12345678".slicing(from: 12, length: 0), nil, error)
+		XCTAssertEqual("12345678".slicing(from: 2, length: 100), "345678", error)
+		XCTAssertEqual("12345678".slicing(from: 2, to: 5), "345", error)
+		XCTAssertEqual("12345678".slicing(from: 2, to: 1), nil, error)
+		XCTAssertEqual("12345678".slicing(at: 2)!, "345678", error)
 	}
 
 	func testSplit() {

--- a/Tests/SwifterSwiftTests/StringExtensionsTests.swift
+++ b/Tests/SwifterSwiftTests/StringExtensionsTests.swift
@@ -159,7 +159,19 @@ class StringExtensionsTests: XCTestCase {
 	func testReversed() {
 		XCTAssert("Hello".reversed == "olleH", "Couldn't get correct value for \(#function) function")
 	}
-	
+
+	func testSlice() {
+		let errMessage = "Couldn't get correct value for \(#function) function"
+		
+		XCTAssertEqual("12345678".slice(at: 2, length: 3)!, "345", errMessage)
+		XCTAssertEqual("12345678".slice(at: 2, length: 0)!, "", errMessage)
+		XCTAssertEqual("12345678".slice(at: 12, length: 0), nil, errMessage)
+		XCTAssertEqual("12345678".slice(at: -2, length: 2)!, "78", errMessage)
+		XCTAssertEqual("12345678".slice(at: 2)!, "3", errMessage)
+		XCTAssertEqual("12345678".slice(at: -1)!, "8", errMessage)
+		XCTAssertEqual("12345678".slice(at: -10), nil, errMessage)
+	}
+
 	func testSplit() {
 		XCTAssert("Hello Tests".splited(by: " ") == ["Hello", "Tests"], "Couldn't get correct value for \(#function)")
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Hello. I am a Ruby developer playing around with Swift for a while now. One of the things I keep missing is **String#slice** method from Ruby stdlib. This is implementation that replicates the behaviour of a Ruby **String#slice** for integer argument types https://ruby-doc.org/core-2.2.0/String.html#method-i-slice . Kind of bombarded it with tests but wanted to cover all the edge cases. Hope that can be useful.

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/omaralbeik/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] I have **only one commit** in this pull request.
- [x] New extensions support iOS 8 or later.
- [x] New extensions are written in Swift 3.
- [x] New extensions were created in **development branch**.
- [ ] Pull request was created to **development head branch**.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All comments headers have the word **SwifterSwift:** before description.
